### PR TITLE
Fix ordinary tax calculation to count income from each tax bracket once

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -114,7 +114,7 @@
 		tax += (inc - ord[keys[i]]) * num(keys[i]) / 100
 		i--;
 		while (i >= 0) {
-			tax += ord[keys[i + 1]] * num(keys[i]) / 100
+			tax += (ord[keys[i + 1]] - ord[keys[i]]) * num(keys[i]) / 100
 			i--;
 		}
 


### PR DESCRIPTION
Closes #4.

Previously, the ordinary tax calculation would multiply the percentage for
the bracket by the **limit** of the bracket instead of the **amount** in
the bracket. In this way, it was counting income from each tax bracket
multiple times (e.g., the first $9525 was getting taxed at 10%, again
at 12%, again at 22%, etc).

This commit ensures that each dollar is taxed once within its tax
bracket. I validated this using the example given in the readme: running
`calculateOrdinaryTax` with `income = 150000` and `filingStatus =
'single'`
does indeed calculate as written, resulting in $30,289.50:

> pay 10% on the first $9,525, 12% on the next $29,175, 22% on the next
> $43,800, and 24% on the remaining $67,500